### PR TITLE
Mark generated files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+entities/api/schema.json	linguist-generated=true
+entities/api/schema.graphql	linguist-generated=true
+entities/cli/gql_schema.py	linguist-generated=true


### PR DESCRIPTION
I think/hope this will suppress generated files from showing up as PR/diffs:
https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github