### PR TITLE
Fix import error

### DIFF
--- a/workflows/database/models/__init__.py
+++ b/workflows/database/models/__init__.py
@@ -1,2 +1,4 @@
-from platformics.database.models.base import Base, meta  # noqa: F401
-from database.models.workflow import Workflow, WorkflowVersion, Run, RunStatus  # noqa: F401
+from platformics.database.models.base import Base, meta
+from database.models.workflow import Workflow, WorkflowVersion, Run, RunStatus, RunStep, RunEntityInput
+
+__all__ = ["Base", "meta", "Workflow", "WorkflowVersion", "Run", "RunStatus", "RunStep", "RunEntityInput"]


### PR DESCRIPTION
An important `import` statement was auto-removed by the linter, adding `noqa` to avoid that 🤔 

Otherwise, running `make init` gives this error:

```python
Traceback (most recent call last):
  File "/workflows/scripts/seed.py", line 2, in <module>
    from factoryboy import workflow_factory as wf
  File "/workflows/factoryboy/workflow_factory.py", line 6, in <module>
    from database.models import Workflow, WorkflowVersion, Run, RunStatus
ImportError: cannot import name 'Workflow' from 'database.models' (/workflows/database/models/__init__.py)
```