### PR TITLE
Fix make local-token inside entities folder

### DIFF
--- a/platformics/Makefile
+++ b/platformics/Makefile
@@ -86,7 +86,7 @@ local-tests: ## Run tests
 
 .PHONY: local-token
 local-token: ## Copy an auth token for this local dev env to the system clipboard
-	TOKEN=$$($(docker_compose_run) $(FOLDER) ./cli/gqlcli.py auth generate-token 111 --project 444:admin --expiration 99999); echo '{"Authorization":"Bearer '$$TOKEN'"}' | tee >(pbcopy)
+	TOKEN=$$($(docker_compose_run) $(FOLDER) ../platformics/cli/generate_token.py auth generate-token 111 --project 444:admin --expiration 99999); echo '{"Authorization":"Bearer '$$TOKEN'"}' | tee >(pbcopy)
 
 .PHONY: fix-lint
 fix-lint: ## Apply linting rules to the code in this directory.


### PR DESCRIPTION
I get an error when running `make local-token` inside entities/ folder because the code to generate the auth code was moved :)