### PR TITLE
local runner nonblocking

### DIFF
--- a/workflows/plugins/workflow_runners/local/workflow_runner_local.py
+++ b/workflows/plugins/workflow_runners/local/workflow_runner_local.py
@@ -104,4 +104,3 @@ class LocalWorkflowRunner(WorkflowRunner):
         )
         thread.start()
         return runner_id
-


### PR DESCRIPTION
This makes the runner for local development more closely mirror what happens in production. It fires the workflow and forgets, the only notification we get on completion comes through the listener.