### PR TITLE
[CZID-8779] Schema improvements

### DIFF
--- a/entities/schema/platformics.yaml
+++ b/entities/schema/platformics.yaml
@@ -33,20 +33,18 @@ enums:
     permissible_values:
       s3:
         description: This file is accessible via the (AWS) S3 protocol
-  Nucleotide:
+  NucleicAcid:
     permissible_values:
-      RNA:
-        description: DNA nucleotide
-      DNA:
-        description: RNA nucleotide
+      RNA
+      DNA
   SequencingProtocol:
     permissible_values:
       MNGS:
-        description: Metagenomics sequencing read
+        description: Metagenomics Sequencing
       TARGETED:
-        description: Targeted (amplified via primers) sequencing read
+        description: Targeted Squencing (amplified via primers)
       MSSPE:
-        description: MSSPE Sequencing Read
+        description: MSSPE Sequencing
   SequencingTechnology:
     permissible_values:
       Illumina:
@@ -178,8 +176,8 @@ classes:
       techonology:
         range: SequencingTechnology
         required: true
-      nucleotide:
-        range: Nucleotide
+      nucleic_acid:
+        range: NucleicAcid
         required: true
       has_ercc:
         range: boolean


### PR DESCRIPTION
Changing `Nucleotide` to `NucleicAcid`. This is because "nucleotides" refer to the individual ACGTU letters, but "nucleic acid" is the category that both DNA and RNA are part of.