### PR TITLE
Don't expose entityId fields in Queries

### DIFF
--- a/entities/api/schema.graphql
+++ b/entities/api/schema.graphql
@@ -59,7 +59,6 @@ type ConsensusGenome implements EntityInterface & Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): MetricConsensusGenomeConnection!
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -125,7 +124,6 @@ type Contig implements EntityInterface & Node {
   collectionId: Int!
   sequencingRead(where: SequencingReadWhereClause = null): SequencingRead
   sequence: String!
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -178,7 +176,6 @@ type CoverageViz implements EntityInterface & Node {
   accessionId: String!
   coverageVizFileId: ID
   coverageVizFile(where: FileWhereClause = null): File
-  entityId: ID!
 }
 
 input CoverageVizCreateInput {
@@ -309,7 +306,6 @@ type GenomicRange implements EntityInterface & Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): ConsensusGenomeConnection!
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -417,7 +413,6 @@ type MetadataField implements EntityInterface & Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): MetadatumConnection!
-  entityId: ID!
 }
 
 input MetadataFieldCreateInput {
@@ -439,7 +434,6 @@ type MetadataFieldProject implements EntityInterface & Node {
   collectionId: Int!
   projectId: Int!
   metadataField(where: MetadataFieldWhereClause = null): MetadataField
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -518,7 +512,6 @@ type Metadatum implements EntityInterface & Node {
   sample(where: SampleWhereClause = null): Sample
   metadataField(where: MetadataFieldWhereClause = null): MetadataField
   value: String!
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -580,7 +573,6 @@ type MetricConsensusGenome implements EntityInterface & Node {
   nAmbiguous: Int
   coverageVizSummaryFileId: ID
   coverageVizSummaryFile(where: FileWhereClause = null): File
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -823,7 +815,6 @@ type ReferenceGenome implements EntityInterface & Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): GenomicRangeConnection!
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -923,7 +914,6 @@ type Sample implements EntityInterface & Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): MetadatumConnection!
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -994,7 +984,6 @@ type SequenceAlignmentIndex implements EntityInterface & Node {
   indexFile(where: FileWhereClause = null): File
   referenceGenome(where: ReferenceGenomeWhereClause = null): ReferenceGenome
   tool: AlignmentTool!
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -1106,7 +1095,6 @@ type SequencingRead implements EntityInterface & Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): ContigConnection!
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -1298,7 +1286,6 @@ type Taxon implements EntityInterface & Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): SampleConnection!
-  entityId: ID!
 }
 
 """A connection to a list of items."""
@@ -1444,7 +1431,6 @@ type UpstreamDatabase implements EntityInterface & Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): TaxonConnection!
-  entityId: ID!
 }
 
 input UpstreamDatabaseCreateInput {

--- a/entities/api/schema.json
+++ b/entities/api/schema.json
@@ -1976,19 +1976,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -2640,19 +2627,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -2804,19 +2778,6 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "TaxonConnection",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
                   "ofType": null
                 }
               }
@@ -5477,19 +5438,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -5864,19 +5812,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -6071,19 +6006,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -6269,19 +6191,6 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "ConsensusGenomeConnection",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
                   "ofType": null
                 }
               }
@@ -6654,19 +6563,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -6886,19 +6782,6 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "AlignmentTool",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
                   "ofType": null
                 }
               }
@@ -7244,19 +7127,6 @@
                 "kind": "OBJECT",
                 "name": "File",
                 "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
               }
             }
           ],
@@ -7711,19 +7581,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -7994,19 +7851,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -8201,19 +8045,6 @@
                 "name": "MetadataField",
                 "ofType": null
               }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -8336,19 +8167,6 @@
                 "kind": "OBJECT",
                 "name": "File",
                 "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "name": "entityId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
               }
             }
           ],

--- a/entities/api/types/consensus_genome.py
+++ b/entities/api/types/consensus_genome.py
@@ -192,7 +192,6 @@ class ConsensusGenome(EntityInterface):
     metrics: Sequence[
         Annotated["MetricConsensusGenome", strawberry.lazy("api.types.metric_consensus_genome")]
     ] = load_metric_consensus_genome_rows  # type:ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/contig.py
+++ b/entities/api/types/contig.py
@@ -84,7 +84,6 @@ class Contig(EntityInterface):
         Annotated["SequencingRead", strawberry.lazy("api.types.sequencing_read")]
     ] = load_sequencing_read_rows  # type:ignore
     sequence: str
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/coverage_viz.py
+++ b/entities/api/types/coverage_viz.py
@@ -86,7 +86,6 @@ class CoverageViz(EntityInterface):
     accession_id: str
     coverage_viz_file_id: Optional[strawberry.ID]
     coverage_viz_file: Optional[Annotated["File", strawberry.lazy("api.files")]] = load_files_from("coverage_viz_file")  # type: ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/genomic_range.py
+++ b/entities/api/types/genomic_range.py
@@ -129,7 +129,6 @@ class GenomicRange(EntityInterface):
     consensus_genomes: Sequence[
         Annotated["ConsensusGenome", strawberry.lazy("api.types.consensus_genome")]
     ] = load_consensus_genome_rows  # type:ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/metadata_field.py
+++ b/entities/api/types/metadata_field.py
@@ -122,7 +122,6 @@ class MetadataField(EntityInterface):
     metadatas: Sequence[
         Annotated["Metadatum", strawberry.lazy("api.types.metadatum")]
     ] = load_metadatum_rows  # type:ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/metadata_field_project.py
+++ b/entities/api/types/metadata_field_project.py
@@ -81,7 +81,6 @@ class MetadataFieldProject(EntityInterface):
     metadata_field: Optional[
         Annotated["MetadataField", strawberry.lazy("api.types.metadata_field")]
     ] = load_metadata_field_rows  # type:ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/metadatum.py
+++ b/entities/api/types/metadatum.py
@@ -99,7 +99,6 @@ class Metadatum(EntityInterface):
         Annotated["MetadataField", strawberry.lazy("api.types.metadata_field")]
     ] = load_metadata_field_rows  # type:ignore
     value: str
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/metric_consensus_genome.py
+++ b/entities/api/types/metric_consensus_genome.py
@@ -117,7 +117,6 @@ class MetricConsensusGenome(EntityInterface):
     n_ambiguous: Optional[int] = None
     coverage_viz_summary_file_id: Optional[strawberry.ID]
     coverage_viz_summary_file: Optional[Annotated["File", strawberry.lazy("api.files")]] = load_files_from("coverage_viz_summary_file")  # type: ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/reference_genome.py
+++ b/entities/api/types/reference_genome.py
@@ -181,7 +181,6 @@ class ReferenceGenome(EntityInterface):
     genomic_ranges: Sequence[
         Annotated["GenomicRange", strawberry.lazy("api.types.genomic_range")]
     ] = load_genomic_range_rows  # type:ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/sample.py
+++ b/entities/api/types/sample.py
@@ -138,7 +138,6 @@ class Sample(EntityInterface):
     metadatas: Sequence[
         Annotated["Metadatum", strawberry.lazy("api.types.metadatum")]
     ] = load_metadatum_rows  # type:ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/sequence_alignment_index.py
+++ b/entities/api/types/sequence_alignment_index.py
@@ -109,7 +109,6 @@ class SequenceAlignmentIndex(EntityInterface):
         Annotated["ReferenceGenome", strawberry.lazy("api.types.reference_genome")]
     ] = load_reference_genome_rows  # type:ignore
     tool: AlignmentTool
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/sequencing_read.py
+++ b/entities/api/types/sequencing_read.py
@@ -176,7 +176,6 @@ class SequencingRead(EntityInterface):
         Annotated["ConsensusGenome", strawberry.lazy("api.types.consensus_genome")]
     ] = load_consensus_genome_rows  # type:ignore
     contigs: Sequence[Annotated["Contig", strawberry.lazy("api.types.contig")]] = load_contig_rows  # type:ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/taxon.py
+++ b/entities/api/types/taxon.py
@@ -206,7 +206,6 @@ class Taxon(EntityInterface):
         Annotated["SequencingRead", strawberry.lazy("api.types.sequencing_read")]
     ] = load_sequencing_read_rows  # type:ignore
     samples: Sequence[Annotated["Sample", strawberry.lazy("api.types.sample")]] = load_sample_rows  # type:ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/api/types/upstream_database.py
+++ b/entities/api/types/upstream_database.py
@@ -83,7 +83,6 @@ class UpstreamDatabase(EntityInterface):
     collection_id: int
     name: str
     taxa: Sequence[Annotated["Taxon", strawberry.lazy("api.types.taxon")]] = load_taxon_rows  # type:ignore
-    entity_id: strawberry.ID
 
 
 # We need to add this to each Queryable type so that strawberry will accept either our

--- a/entities/cli/gql_schema.py
+++ b/entities/cli/gql_schema.py
@@ -2189,7 +2189,6 @@ class ConsensusGenome(sgqlc.types.Type, EntityInterface, Node):
         "intermediate_outputs_id",
         "intermediate_outputs",
         "metrics",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2247,20 +2246,11 @@ class ConsensusGenome(sgqlc.types.Type, EntityInterface, Node):
             )
         ),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class Contig(sgqlc.types.Type, EntityInterface, Node):
     __schema__ = gql_schema
-    __field_names__ = (
-        "id",
-        "producing_run_id",
-        "owner_user_id",
-        "collection_id",
-        "sequencing_read",
-        "sequence",
-        "entity_id",
-    )
+    __field_names__ = ("id", "producing_run_id", "owner_user_id", "collection_id", "sequencing_read", "sequence")
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
     owner_user_id = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name="ownerUserId")
@@ -2273,7 +2263,6 @@ class Contig(sgqlc.types.Type, EntityInterface, Node):
         ),
     )
     sequence = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name="sequence")
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class CoverageViz(sgqlc.types.Type, EntityInterface, Node):
@@ -2286,7 +2275,6 @@ class CoverageViz(sgqlc.types.Type, EntityInterface, Node):
         "accession_id",
         "coverage_viz_file_id",
         "coverage_viz_file",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2299,7 +2287,6 @@ class CoverageViz(sgqlc.types.Type, EntityInterface, Node):
         graphql_name="coverageVizFile",
         args=sgqlc.types.ArgDict((("where", sgqlc.types.Arg(FileWhereClause, graphql_name="where", default=None)),)),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class GenomicRange(sgqlc.types.Type, EntityInterface, Node):
@@ -2313,7 +2300,6 @@ class GenomicRange(sgqlc.types.Type, EntityInterface, Node):
         "file_id",
         "file",
         "consensus_genomes",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2345,7 +2331,6 @@ class GenomicRange(sgqlc.types.Type, EntityInterface, Node):
             )
         ),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class MetadataField(sgqlc.types.Type, EntityInterface, Node):
@@ -2363,7 +2348,6 @@ class MetadataField(sgqlc.types.Type, EntityInterface, Node):
         "options",
         "default_value",
         "metadatas",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2401,20 +2385,11 @@ class MetadataField(sgqlc.types.Type, EntityInterface, Node):
             )
         ),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class MetadataFieldProject(sgqlc.types.Type, EntityInterface, Node):
     __schema__ = gql_schema
-    __field_names__ = (
-        "id",
-        "producing_run_id",
-        "owner_user_id",
-        "collection_id",
-        "project_id",
-        "metadata_field",
-        "entity_id",
-    )
+    __field_names__ = ("id", "producing_run_id", "owner_user_id", "collection_id", "project_id", "metadata_field")
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
     owner_user_id = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name="ownerUserId")
@@ -2427,21 +2402,11 @@ class MetadataFieldProject(sgqlc.types.Type, EntityInterface, Node):
             (("where", sgqlc.types.Arg(MetadataFieldWhereClause, graphql_name="where", default=None)),)
         ),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class Metadatum(sgqlc.types.Type, EntityInterface, Node):
     __schema__ = gql_schema
-    __field_names__ = (
-        "id",
-        "producing_run_id",
-        "owner_user_id",
-        "collection_id",
-        "sample",
-        "metadata_field",
-        "value",
-        "entity_id",
-    )
+    __field_names__ = ("id", "producing_run_id", "owner_user_id", "collection_id", "sample", "metadata_field", "value")
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
     owner_user_id = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name="ownerUserId")
@@ -2459,7 +2424,6 @@ class Metadatum(sgqlc.types.Type, EntityInterface, Node):
         ),
     )
     value = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name="value")
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class MetricConsensusGenome(sgqlc.types.Type, EntityInterface, Node):
@@ -2478,7 +2442,6 @@ class MetricConsensusGenome(sgqlc.types.Type, EntityInterface, Node):
         "n_ambiguous",
         "coverage_viz_summary_file_id",
         "coverage_viz_summary_file",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2503,7 +2466,6 @@ class MetricConsensusGenome(sgqlc.types.Type, EntityInterface, Node):
         graphql_name="coverageVizSummaryFile",
         args=sgqlc.types.ArgDict((("where", sgqlc.types.Arg(FileWhereClause, graphql_name="where", default=None)),)),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class ReferenceGenome(sgqlc.types.Type, EntityInterface, Node):
@@ -2524,7 +2486,6 @@ class ReferenceGenome(sgqlc.types.Type, EntityInterface, Node):
         "sequence_alignment_indices",
         "consensus_genomes",
         "genomic_ranges",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2589,7 +2550,6 @@ class ReferenceGenome(sgqlc.types.Type, EntityInterface, Node):
             )
         ),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class Sample(sgqlc.types.Type, EntityInterface, Node):
@@ -2608,7 +2568,6 @@ class Sample(sgqlc.types.Type, EntityInterface, Node):
         "host_taxon",
         "sequencing_reads",
         "metadatas",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2651,7 +2610,6 @@ class Sample(sgqlc.types.Type, EntityInterface, Node):
             )
         ),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class SequenceAlignmentIndex(sgqlc.types.Type, EntityInterface, Node):
@@ -2665,7 +2623,6 @@ class SequenceAlignmentIndex(sgqlc.types.Type, EntityInterface, Node):
         "index_file",
         "reference_genome",
         "tool",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2685,7 +2642,6 @@ class SequenceAlignmentIndex(sgqlc.types.Type, EntityInterface, Node):
         ),
     )
     tool = sgqlc.types.Field(sgqlc.types.non_null(AlignmentTool), graphql_name="tool")
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class SequencingRead(sgqlc.types.Type, EntityInterface, Node):
@@ -2709,7 +2665,6 @@ class SequencingRead(sgqlc.types.Type, EntityInterface, Node):
         "primer_file",
         "consensus_genomes",
         "contigs",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2773,7 +2728,6 @@ class SequencingRead(sgqlc.types.Type, EntityInterface, Node):
             )
         ),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class Taxon(sgqlc.types.Type, EntityInterface, Node):
@@ -2804,7 +2758,6 @@ class Taxon(sgqlc.types.Type, EntityInterface, Node):
         "reference_genomes",
         "sequencing_reads",
         "samples",
-        "entity_id",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
@@ -2887,12 +2840,11 @@ class Taxon(sgqlc.types.Type, EntityInterface, Node):
             )
         ),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 class UpstreamDatabase(sgqlc.types.Type, EntityInterface, Node):
     __schema__ = gql_schema
-    __field_names__ = ("id", "producing_run_id", "owner_user_id", "collection_id", "name", "taxa", "entity_id")
+    __field_names__ = ("id", "producing_run_id", "owner_user_id", "collection_id", "name", "taxa")
     id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="id")
     producing_run_id = sgqlc.types.Field(Int, graphql_name="producingRunId")
     owner_user_id = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name="ownerUserId")
@@ -2911,7 +2863,6 @@ class UpstreamDatabase(sgqlc.types.Type, EntityInterface, Node):
             )
         ),
     )
-    entity_id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name="entityId")
 
 
 ########################################################################

--- a/entities/codegen/templates/api/types/class_name.py.j2
+++ b/entities/codegen/templates/api/types/class_name.py.j2
@@ -159,7 +159,9 @@ class {{ cls.name }}(EntityInterface):
     collection_id: int
     {%- for attr in cls.owned_fields %}
         {%- if attr.type == "uuid" %}
+           {%- if attr.name != "entity_id" %}
     {{ attr.name }}: {{ getType("strawberry.ID", attr.required) }}
+           {%- endif %}
         {%- elif attr.type == "string" %}
     {{ attr.name }}: {{ getType("str", attr.required) }}
         {%- elif attr.is_enum %}


### PR DESCRIPTION
exposing both `id` and `entityId` is confusing - let's only expose `id`