### PR TITLE
stop mypy from validating codegen that doesn't work in workflows

### DIFF
--- a/workflows/pyproject.toml
+++ b/workflows/pyproject.toml
@@ -52,8 +52,8 @@ line-length = 120
 explicit_package_bases = true
 ignore_missing_imports = true
 disallow_untyped_defs = true
-implicit_reexport = false
-exclude = ['gql_schema\.py$', '^platformics/thirdparty']
+implicit_reexport = true
+exclude = ['gql_schema\.py$', '^platformics/thirdparty', '^platformics/codegen']
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.


### PR DESCRIPTION
* Running into linting issues from moving the codegen folder into platformics
* In general we probably don't want to turn on mypy for the `workflows/platformics/codegen/` folder until we know that everything in codegen can work with both entities and workflows
