### PR TITLE
Fix dataloader hash lookups

### DIFF
--- a/platformics/api/tests/test_hashability.py
+++ b/platformics/api/tests/test_hashability.py
@@ -6,7 +6,7 @@ import datetime
 import enum
 
 import strawberry
-from platformics.api.core.gql_loaders import make_hashable
+from platformics.api.core.gql_loaders import get_where_hash
 
 
 @strawberry.enum
@@ -24,7 +24,7 @@ def test_hash_consistency() -> None:
         "description": {"_ilike": {"not": {"nested": "%b%"}}, "key1": "kaboom"},
         "list_thing": ["10", "11", "12"],
     }
-    assert hash(make_hashable(where_1)) == hash(make_hashable(where_2))
+    assert get_where_hash(where_1) == get_where_hash(where_2)
 
 
 def test_hash_inconsistency() -> None:
@@ -36,13 +36,13 @@ def test_hash_inconsistency() -> None:
         "description": {"_ilike": {"not": {"nested": "%b%"}}, "key1": "kaboom"},
         "list_thing": ["10", "11", "12"],
     }
-    assert hash(make_hashable(where_1)) != hash(make_hashable(where_2))
+    assert get_where_hash(where_1) != get_where_hash(where_2)
     where_2 = {
         "description": {"key1": "kaboom", "_ilike": {"not": {"nested": "%c%"}}},
         "list_thing": ["10", "11", "12"],
         "extra_item": "foo",
     }
-    assert hash(make_hashable(where_1)) != hash(make_hashable(where_2))
+    assert get_where_hash(where_1) != get_where_hash(where_2)
 
 
 def test_list_comparisons() -> None:
@@ -55,14 +55,20 @@ def test_list_comparisons() -> None:
         "description": {"_ilike": {"not": {"nested": "%b%"}}, "key1": "kaboom"},
         "nested": {"list_thing": ["10", "11", "12"]},
     }
-    assert hash(make_hashable(where_1)) == hash(make_hashable(where_2))
+    assert get_where_hash(where_1) == get_where_hash(where_2)
 
-    # inequality
+    # inequality in nested lists
     where_2 = {
         "description": {"_ilike": {"not": {"nested": "%b%"}}, "key1": "kaboom"},
         "nested": {"list_thing": ["10", "11", "12", "13"]},
     }
-    assert hash(make_hashable(where_1)) != hash(make_hashable(where_2))
+    assert get_where_hash(where_1) != get_where_hash(where_2)
+    # inequality in nested keys
+    where_1 = {
+        "description": {"key2": "kaboom", "_ilike": {"not": {"nested": "%b%"}}},
+        "nested": {"list_thing": ["10", "11", "12"]},
+    }
+    assert get_where_hash(where_1) != get_where_hash(where_2)
 
 
 def test_hash_compairsons_with_weird_types() -> None:
@@ -75,13 +81,13 @@ def test_hash_compairsons_with_weird_types() -> None:
         "description": {"_ilike": {"not": {"nested": MyTestEnum.option_2}}, "key1": "kaboom"},
         "list_thing": ["10", "11", "12"],
     }
-    assert hash(make_hashable(where_1)) == hash(make_hashable(where_2))
+    assert get_where_hash(where_1) == get_where_hash(where_2)
     # Enum inequality
     where_2 = {
         "description": {"_ilike": {"not": {"nested": MyTestEnum.option_1}}, "key1": "kaboom"},
         "list_thing": ["10", "11", "12"],
     }
-    assert hash(make_hashable(where_1)) != hash(make_hashable(where_2))
+    assert get_where_hash(where_1) != get_where_hash(where_2)
 
     # Date equality
     where_1 = {
@@ -92,11 +98,11 @@ def test_hash_compairsons_with_weird_types() -> None:
         "description": {"_ilike": {"not": {"nested": datetime.datetime(2022, 1, 1, 10, 20)}}, "key1": "kaboom"},
         "list_thing": ["10", "11", "12"],
     }
-    assert hash(make_hashable(where_1)) == hash(make_hashable(where_2))
+    assert get_where_hash(where_1) == get_where_hash(where_2)
 
     # Date inequality
     where_2 = {
         "description": {"_ilike": {"not": {"nested": datetime.datetime(2023, 1, 1, 10, 20)}}, "key1": "kaboom"},
         "list_thing": ["10", "11", "12"],
     }
-    assert hash(make_hashable(where_1)) != hash(make_hashable(where_2))
+    assert get_where_hash(where_1) != get_where_hash(where_2)


### PR DESCRIPTION
The previous hashing implementation for where clauses was broken and didn't consider hash values! 😱 

This one is more thorough and shouldn't create unnecessary hash collisions with the structure of our where clauses.