### PR TITLE
Server can't start without codegen

### DIFF
--- a/entities/Makefile
+++ b/entities/Makefile
@@ -35,6 +35,7 @@ local-setup: ## Load db tables and seed data
 	while [ -z "$$($(docker_compose) exec -T entities-db psql $(LOCAL_DB_CONN_STRING) -c 'select 1')" ]; do echo "waiting for db to start..."; sleep 1; done;
 	$(docker_compose_run) entities alembic upgrade head
 	$(MAKE) local-seed
+	$(MAKE) codegen-test-schema
 
 .PHONY: local-start
 local-start: ## Start a local dev environment that's been stopped.


### PR DESCRIPTION
Server can't start without codegen. Otherwise get:

```
2023-12-21 10:21:54 entities-1     |     from platformics.codegen.tests.output.api.queries import Query as QueryCodeGen
2023-12-21 10:21:54 entities-1     | ModuleNotFoundError: No module named 'platformics.codegen.tests.output'
```