### PR TITLE
Add general purpose indexes.

### DIFF
--- a/entities/database/migrations/versions/20240129_100617_add_relationship_indexes.py
+++ b/entities/database/migrations/versions/20240129_100617_add_relationship_indexes.py
@@ -3,7 +3,6 @@
 Create Date: 2024-01-29 15:06:17.946251
 
 """
-import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
Our DB was missing indexes on ~all fk fields. This is just an effort to take care of some of the low-hanging fruit and add indexes to fields that seem very likely to need them. We'll need to add more over time as we learn more about the query patterns that our clients tend to use.