### PR TITLE
Fix seed script issue

### DIFF
--- a/entities/test_infra/factories/main.py
+++ b/entities/test_infra/factories/main.py
@@ -98,8 +98,8 @@ class FileFactory(factory.alchemy.SQLAlchemyModelFactory):
                     entity_name = entity.type
                     session.execute(
                         sa.text(
-                            f"""UPDATE {entity_name} SET {entity_field_name}_id = file.id
-                            FROM file WHERE {entity_name}.entity_id = file.entity_id""",
+                            f"""UPDATE {entity_name} SET {entity_field_name}_id = '{file.id}'
+                            WHERE entity_id = '{file.entity_id}'""",
                         )
                     )
         session.commit()

--- a/workflows/test_infra/factories/main.py
+++ b/workflows/test_infra/factories/main.py
@@ -97,8 +97,8 @@ class FileFactory(factory.alchemy.SQLAlchemyModelFactory):
                     entity_name = entity.type
                     session.execute(
                         sa.text(
-                            f"""UPDATE {entity_name} SET {entity_field_name}_id = file.id
-                            FROM file WHERE {entity_name}.entity_id = file.entity_id""",
+                            f"""UPDATE {entity_name} SET {entity_field_name}_id = '{file.id}'
+                            WHERE entity_id = '{file.entity_id}'""",
                         )
                     )
         session.commit()


### PR DESCRIPTION
Small fix to the seed script so that 1 file is not assigned to multiple File objects in one entity.

Example before this fix: SequencingRead.r1_file == SequencingRead.r2_file, but there's still 2 File objects, one of which isn't referenced from anywhere
