### PR TITLE
[CZID-9324] Update data model for workflow run deletions

### DIFF
--- a/workflows/database/models/workflow_run.py
+++ b/workflows/database/models/workflow_run.py
@@ -53,12 +53,14 @@ class WorkflowRun(Entity):
         back_populates="workflow_run",
         uselist=True,
         foreign_keys="WorkflowRunStep.workflow_run_id",
+        cascade="all, delete-orphan",
     )
     entity_inputs: Mapped[list[WorkflowRunEntityInput]] = relationship(
         "WorkflowRunEntityInput",
         back_populates="workflow_run",
         uselist=True,
         foreign_keys="WorkflowRunEntityInput.workflow_run_id",
+        cascade="all, delete-orphan",
     )
     raw_inputs_json: Mapped[str] = mapped_column(String, nullable=True)
     deprecated_by_id: Mapped[uuid.UUID] = mapped_column(

--- a/workflows/schema/workflows.yaml
+++ b/workflows/schema/workflows.yaml
@@ -120,10 +120,14 @@ classes:
         range: WorkflowRunStep
         multivalued: true
         inverse: WorkflowRunStep.workflow_run
+        annotations:
+          cascade_delete: true
       entity_inputs:
         range: WorkflowRunEntityInput
         multivalued: true
         inverse: RunEntityInput.workflow_run
+        annotations:
+          cascade_delete: true
       raw_inputs_json:
         range: string
         annotations:


### PR DESCRIPTION
This ended up being a fairly simple application of code-gen. I specifically did not apply cascade deletes to workflow versions and workflows because we want to keep the underlying runs around even if one is deleted.