### PR TITLE
Fix bug with loaders

### DIFF
--- a/workflows/api/loader/run_loader.py
+++ b/workflows/api/loader/run_loader.py
@@ -41,6 +41,8 @@ if __name__ == "__main__":
 
     # start server for health check
     t = threading.Thread(target=health_check)
+    # this will ensure the thread is killed when the main thread is killed
+    t.daemon = True
     t.start()
 
     task = loop.create_task(loader.main())

--- a/workflows/api/main.py
+++ b/workflows/api/main.py
@@ -252,6 +252,8 @@ async def _run_workflow_run(
                 workflow_path=workflow_version.workflow_uri,
                 inputs=workflow_runner_inputs_json,
             )
+        else:
+            status = WorkflowRunStatus.RUNNING
     except Exception as e:
         logger.error(f"Failed to run workflow {workflow_version.id}: {e}")
         status = WorkflowRunStatus.FAILED


### PR DESCRIPTION
There are two things that are wrong, possibly more but let's see if this fixes it.

1. If we already have an ARN the start event for that ARN has probably already been processed but the workflow didn't have the ARN yet. This keeps the workflow in a pending state preventing it from getting to running. If we get an ARN we should skip straight to running because an ARN means it is running.
2. Right now if the loader throws any error at all it will crash. This is on purpose because the container can restart. However, because the health check is running in a different processes kubernetes thinks it is still healthy. By making this a deamon processes the health check server will shut down when the main process fails.