### PR TITLE
Add support for regex filter variants

### DIFF
--- a/platformics/api/core/gql_to_sql.py
+++ b/platformics/api/core/gql_to_sql.py
@@ -25,9 +25,9 @@ operator_map = {
     "_ilike": "ilike",
     "_nilike": "notilike",
     "_regex": "regexp_match",
-    # "_nregex": Optional[str] # TODO
-    # "_iregex": Optional[str]# TODO
-    # "_niregex": Optional[str]# TODO
+    "_nregex": {"comparator": "regexp_match", "should_negate": True, "flag": None},
+    "_iregex": {"comparator": "regexp_match", "should_negate": False, "flag": "i"},
+    "_niregex": {"comparator": "regexp_match", "should_negate": True, "flag": "i"},
 }
 
 aggregator_map = {

--- a/platformics/api/core/helpers.py
+++ b/platformics/api/core/helpers.py
@@ -164,6 +164,14 @@ def convert_where_clauses_to_sql(
                     query = query.filter(getattr(sa_model, col).is_(None))
                 else:
                     query = query.filter(getattr(sa_model, col).isnot(None))
+            elif sa_comparator == "not_regexp_match":
+                query = query.filter(~(getattr(getattr(sa_model, col), "regexp_match"))(value))
+            # For the variants of regexp_match, we pass in a dict with the comparator, should_negate, and flag
+            elif isinstance(sa_comparator, dict):
+                if sa_comparator["should_negate"]:
+                    query = query.filter(~(getattr(getattr(sa_model, col), sa_comparator["comparator"])(value, sa_comparator["flag"])))
+                else:
+                    query = query.filter(getattr(getattr(sa_model, col), sa_comparator["comparator"])(value, sa_comparator["flag"]))
             else:
                 query = query.filter(getattr(getattr(sa_model, col), sa_comparator)(value))
 

--- a/platformics/api/core/helpers.py
+++ b/platformics/api/core/helpers.py
@@ -164,8 +164,6 @@ def convert_where_clauses_to_sql(
                     query = query.filter(getattr(sa_model, col).is_(None))
                 else:
                     query = query.filter(getattr(sa_model, col).isnot(None))
-            elif sa_comparator == "not_regexp_match":
-                query = query.filter(~(getattr(getattr(sa_model, col), "regexp_match"))(value))
             # For the variants of regexp_match, we pass in a dict with the comparator, should_negate, and flag
             elif isinstance(sa_comparator, dict):
                 if sa_comparator["should_negate"]:


### PR DESCRIPTION
Adds support for `_iregex`, `_nregex`, and `_niregex` in the `where` clause!

Super basic test:
* All the sample names, for reference
<img width="1006" alt="Screenshot 2024-03-21 at 10 42 23 AM" src="https://github.com/chanzuckerberg/czid-platformics/assets/53838890/30683073-3e68-4340-8611-2f2f93f5a6f7">

* Match regex, case sensitive (this was already implemented)
<img width="1002" alt="Screenshot 2024-03-21 at 10 42 33 AM" src="https://github.com/chanzuckerberg/czid-platformics/assets/53838890/8e95cb0d-927b-4614-b6ac-9cb94efb404b">

* Match regex, case insensitive
<img width="1015" alt="Screenshot 2024-03-21 at 10 42 43 AM" src="https://github.com/chanzuckerberg/czid-platformics/assets/53838890/d857e916-2dc8-4e93-86d9-522fe1c94ab2">

* Do not match regex, case sensitive
<img width="998" alt="Screenshot 2024-03-21 at 10 42 51 AM" src="https://github.com/chanzuckerberg/czid-platformics/assets/53838890/5642d699-1756-431f-acd3-163034a8c932">

* Do not match regex, case insensitive
<img width="988" alt="Screenshot 2024-03-21 at 10 43 00 AM" src="https://github.com/chanzuckerberg/czid-platformics/assets/53838890/2d7a007e-7e0e-43d0-b92f-b271f2c37690">
