### PR TITLE
Increase sample name max length

### DIFF
--- a/entities/api/validators/sample.py
+++ b/entities/api/validators/sample.py
@@ -24,7 +24,7 @@ class SampleCreateInputValidator(BaseModel):
         StringConstraints(
             strip_whitespace=True,
             min_length=4,
-            max_length=64,
+            max_length=128,
         ),
     ]
     host_organism_id: Annotated[uuid.UUID | None, Field()]
@@ -46,7 +46,7 @@ class SampleUpdateInputValidator(BaseModel):
         StringConstraints(
             strip_whitespace=True,
             min_length=4,
-            max_length=64,
+            max_length=128,
         ),
     ]
     deleted_at: Annotated[datetime.datetime | None, Field()]

--- a/entities/schema/platformics.yaml
+++ b/entities/schema/platformics.yaml
@@ -269,7 +269,7 @@ classes:
         required: true
         annotations:
             minimum_length: 4
-            maximum_length: 64
+            maximum_length: 128
       # TODO: Uncomment when we migrate metadata
       # sample_type:
       #   range: string


### PR DESCRIPTION
Got some errors during upload due to a sample name being too long.

TBH not entirely sure what a reasonable max length for these are, but given that our benchmark sample names are 80+ characters (they look like `idseq-bench-5|1711562736|norg_13|nacc_35|uniform_weight_per_organism|hiseq_reads|v10`), 64 seems too low. I just doubled it to 128, hopefully that is enough!