### PR TITLE
Filter out soft-deleted data from all query results by default

### DIFF
--- a/platformics/codegen/tests/test_field_visibility.py
+++ b/platformics/codegen/tests/test_field_visibility.py
@@ -74,12 +74,6 @@ async def test_hidden_mutations(
     output = await gql_client.query(query, user_id=user_id, member_projects=[project_id])
     mutations = [field["name"] for field in output["data"]["__schema"]["mutationType"]["fields"]]
 
-    # There are no mutable fields on GenomicRange (some are readonly, and others are mutable: false), so we shouldn't have a mutation for it.
-    assert "updateGenomicRange" not in mutations
-
-    # However we *can* create a genomic range.
-    assert "createGenomicRange" in mutations
-
     # ImmutableType has `mutable: false` set on the entire table so it shouldn't have a mutation
     assert "updateImmutableType" not in mutations
 
@@ -136,7 +130,7 @@ async def test_update_fields(
     ]
     fields = [field["name"] for field in create_type["inputFields"]]
     # We have a limited subset of mutable fields on SequencingRead
-    assert set(fields) == set(["nucleicAcid", "clearlabsExport", "technology", "sampleId"])
+    assert set(fields) == set(["nucleicAcid", "clearlabsExport", "technology", "sampleId", "deletedAt"])
 
 
 # Make sure we only allow certain fields to be set at entity creation time.
@@ -187,4 +181,4 @@ async def test_creation_fields(
     fields = [field["name"] for field in create_type["inputFields"]]
     # Producing run id and collection id are always settable on a new entity.
     # producingRunId is only settable by a system user, and collectionId is settable by users.
-    assert set(fields) == set(["producingRunId", "collectionId"])
+    assert set(fields) == set(["producingRunId", "collectionId", "deletedAt"])

--- a/platformics/codegen/tests/test_schemas/platformics.yaml
+++ b/platformics/codegen/tests/test_schemas/platformics.yaml
@@ -109,6 +109,8 @@ classes:
       updated_at:
         range: date
         readonly: true
+      deleted_at:
+        range: date
     # NOTE - the LinkML schema doesn't support a native "plural name" field as far as I can tell, so
     # we're using an annotation here to tack on the extra functionality that we need. We do this because
     # English pluralization is hard, and we don't want to have to write a custom pluralization function.

--- a/platformics/codegen/tests/test_where_clause.py
+++ b/platformics/codegen/tests/test_where_clause.py
@@ -245,3 +245,55 @@ async def test_where_clause_regex_match(sync_db: SyncDB, gql_client: GQLTestClie
     assert len(no_match_ignore_case_query_output["data"]["samples"]) == 2
     output_sample_names = [sample["name"] for sample in no_match_ignore_case_query_output["data"]["samples"]]
     assert sorted(output_sample_names) == sorted(no_matches)
+
+@pytest.mark.asyncio
+async def test_soft_deleted_objects(sync_db: SyncDB, gql_client: GQLTestClient) -> None:
+    """
+    Verify that the where clause works as expected with soft-deleted objects.
+    By default, soft-deleted objects should not be returned.
+    """
+    sequencing_reads = generate_sequencing_reads(sync_db)
+    # Soft delete the first 3 sequencing reads by updating the deleted_at field
+    deleted_ids = [str(sequencing_reads[0].id), str(sequencing_reads[1].id), str(sequencing_reads[2].id)]
+    query = f"""
+        mutation DeleteSequencingReads {{
+            updateSequencingRead (
+                where: {{
+                    id: {{ _in: [ "{deleted_ids[0]}", "{deleted_ids[1]}", "{deleted_ids[2]}" ] }},
+                }},
+                input: {{
+                    deletedAt: "2021-01-01T00:00:00Z",
+                }}
+            ) {{
+                id
+            }}
+        }}
+    """
+    output = await gql_client.query(query, member_projects=[project_id])
+    assert len(output["data"]["updateSequencingRead"]) == 3
+
+    # Check that the soft-deleted sequencing reads are not returned
+    query = """
+        query GetSequencingReads {
+            sequencingReads {
+                id
+            }
+        }
+    """
+    output = await gql_client.query(query, member_projects=[project_id])
+    assert len(output["data"]["sequencingReads"]) == 2
+    for sequencing_read in output["data"]["sequencingReads"]:
+        assert sequencing_read["id"] not in deleted_ids
+
+    # Check that the soft-deleted sequencing reads are returned when explicitly requested
+    query = """
+        query GetSequencingReads {
+            sequencingReads ( where: { deletedAt: { _is_null: false } }) {
+                id
+            }
+        }
+    """
+    output = await gql_client.query(query, member_projects=[project_id])
+    assert len(output["data"]["sequencingReads"]) == 3
+    for sequencing_read in output["data"]["sequencingReads"]:
+        assert sequencing_read["id"] in deleted_ids


### PR DESCRIPTION
Filter out soft-deleted data (i.e. objects where the `deletedAt` timestamp is not `null`) by default. The client can still fetch soft-deleted data if it's specifically requested.

This also applies to aggregate queries.

For example, if there are 5 total samples, but 2 have been soft-deleted:
* This query:
  ```gql
  query MyQuery {
    samples {
      id
    }
  }
  ```
  will return the 3 non-deleted samples.

* And this query:
  ```gql
  query MyQuery {
    samples(where: {deletedAt: {_is_null: false}}) {
      id
    }
  }
  ```
  will return the 2 soft-deleted samples.

Tests have been added/updated! [The wiki has also been updated](https://github.com/chanzuckerberg/czid-platformics/wiki/Entities-%E2%80%90-Example-GraphQL-queries#soft-deleted-data).